### PR TITLE
Folders handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,3 @@ Hot reloading for development, but step building is required.
 ![Load Extension](docs/readme-chrome-extensions.webp "Enable developer mode & load unpacked extension")
 
 That's it, when you edit your code, to be sure to see last update on your chrome, use the "reload extension" button on chrome://extensions.
-
-### Roadmap
-
-- [x] Add a button 'restore settings' in options.html
-- [x] Make strapi url configurable
-- [] Do not recreate rootNode : save its id in config, remove only its childrens on sync
-- [] Optim onboarding 😃
-- [] Let user select bookmark folders to sync (using tag, category...)
-- [] Use up to date strategies : https://developer.chrome.com/docs/extensions/mv3/migrating_to_service_workers/

--- a/src/js/strapi/provider.js
+++ b/src/js/strapi/provider.js
@@ -2,6 +2,20 @@ import StrapiHttpClient from "./api";
 
 const UNDEFINED_CATEGORY_LABEL = "Undefined category";
 
+const mapServerFolder = folder => {
+  const { id, name, bookmarks, children } = folder;
+  let childrens = [];
+  childrens = bookmarks.map(bookmark => ({ id: bookmark.id, itle: bookmark.title, url: bookmark.url }));
+  let childrenMapped = children.map(mapServerFolder);
+  childrens.push(...childrenMapped);
+  return {
+    id,
+    type: "directory",
+    title: name,
+    childrens,
+  };
+};
+
 /**
  * Load and parse bookmarks tree from strapi
  *
@@ -11,39 +25,7 @@ const UNDEFINED_CATEGORY_LABEL = "Undefined category";
 export async function loadBookmarksTree(config) {
   // Fetch all required info
   const httpClient = new StrapiHttpClient(config);
-  const tags = await httpClient.getTags();
+  const foldersTree = await httpClient.getFoldersTree();
 
-  // Prepare data
-  const undefinedCategory = { id: -1, name: UNDEFINED_CATEGORY_LABEL, type: "directory" };
-  const tagsByCategoryId = tags.reduce((agg, tag) => {
-    const categoryId = [tag.tags_category ? tag.tags_category.id : -1];
-    const categoryTags = agg[categoryId] || [];
-    categoryTags.push({
-      id: tag.id,
-      title: tag.name,
-      type: "directory",
-      childrens: tag.bookmarks.map(({ id, title, url }) => ({ id, title, url, type: "bookmark" })),
-    });
-
-    return {
-      ...agg,
-      [categoryId]: categoryTags,
-    };
-  }, {});
-  const categoriesById = tags.reduce((agg, tag) => {
-    const category = tag.tags_category || undefinedCategory;
-    if (agg[category.id]) return agg;
-
-    return {
-      ...agg,
-      [category.id]: {
-        type: "directory",
-        title: category.name,
-        id: category.id,
-        childrens: tagsByCategoryId[category.id],
-      },
-    };
-  }, {});
-
-  return Object.values(categoriesById);
+  return foldersTree.map(mapServerFolder);
 }

--- a/src/js/strapi/provider.js
+++ b/src/js/strapi/provider.js
@@ -2,10 +2,20 @@ import StrapiHttpClient from "./api";
 
 const UNDEFINED_CATEGORY_LABEL = "Undefined category";
 
+/**
+ * Mapping a folder to a chrome directory with bookmarks
+ * @param {Object} folder folder from the server
+ * @returns
+ */
 const mapServerFolder = folder => {
   const { id, name, bookmarks, children } = folder;
   let childrens = [];
-  childrens = bookmarks.map(bookmark => ({ id: bookmark.id, itle: bookmark.title, url: bookmark.url }));
+  childrens = bookmarks.map(bookmark => ({
+    id: bookmark.id,
+    title: bookmark.title,
+    url: bookmark.url,
+    type: "bookmark",
+  }));
   let childrenMapped = children.map(mapServerFolder);
   childrens.push(...childrenMapped);
   return {

--- a/test/strapi/data.test.js
+++ b/test/strapi/data.test.js
@@ -88,8 +88,6 @@ export const classicalTagsExpectedResult = [
   },
 ];
 
-export const strapiConfig = { strapiUrl: "http://mock.test/", strapiJwt: "jwtMock" };
-
 export const classicalFolders = [
   {
     id: 1,
@@ -186,3 +184,32 @@ export const classicalFolders = [
     children: [],
   },
 ];
+
+export const classicalFoldersExpectedResult = [
+  {
+    id: 1,
+    type: "directory",
+    title: "A",
+    childrens: [
+      { id: 1, itle: "B1", url: "http://dzad.fr" },
+      {
+        id: 2,
+        type: "directory",
+        title: "B",
+        childrens: [
+          { id: 2, itle: "B2", url: "http://fezfzefz.fez" },
+          { id: 3, itle: "B3", url: "http://dadazdaf.fre" },
+          {
+            id: 4,
+            type: "directory",
+            title: "D",
+            childrens: [{ id: 2, itle: "B2", url: "http://fezfzefz.fez" }],
+          },
+        ],
+      },
+    ],
+  },
+  { id: 3, type: "directory", title: "C", childrens: [{ id: 2, itle: "B2", url: "http://fezfzefz.fez" }] },
+];
+
+export const strapiConfig = { strapiUrl: "http://mock.test/", strapiJwt: "jwtMock" };

--- a/test/strapi/data.test.js
+++ b/test/strapi/data.test.js
@@ -89,3 +89,100 @@ export const classicalTagsExpectedResult = [
 ];
 
 export const strapiConfig = { strapiUrl: "http://mock.test/", strapiJwt: "jwtMock" };
+
+export const classicalFolders = [
+  {
+    id: 1,
+    name: "A",
+    parent: null,
+    created_at: "2021-04-02T20:52:42.989Z",
+    updated_at: "2021-04-02T21:16:15.966Z",
+    bookmarks: [
+      {
+        id: 1,
+        title: "B1",
+        url: "http://dzad.fr",
+        description: null,
+        created_at: "2021-04-02T20:51:22.590Z",
+        updated_at: "2021-04-02T21:15:26.871Z",
+      },
+    ],
+    children: [
+      {
+        id: 2,
+        name: "B",
+        parent: {
+          id: 1,
+          name: "A",
+          parent: null,
+          created_at: "2021-04-02T20:52:42.989Z",
+          updated_at: "2021-04-02T21:16:15.966Z",
+        },
+        created_at: "2021-04-02T20:52:52.566Z",
+        updated_at: "2021-04-02T21:16:25.494Z",
+        bookmarks: [
+          {
+            id: 2,
+            title: "B2",
+            url: "http://fezfzefz.fez",
+            description: null,
+            created_at: "2021-04-02T20:52:15.527Z",
+            updated_at: "2021-04-02T21:15:35.603Z",
+          },
+          {
+            id: 3,
+            title: "B3",
+            url: "http://dadazdaf.fre",
+            description: null,
+            created_at: "2021-04-02T20:52:30.298Z",
+            updated_at: "2021-04-02T21:15:42.543Z",
+          },
+        ],
+        children: [
+          {
+            id: 4,
+            name: "D",
+            parent: {
+              id: 2,
+              name: "B",
+              parent: 1,
+              created_at: "2021-04-02T20:52:52.566Z",
+              updated_at: "2021-04-02T21:16:25.494Z",
+            },
+            created_at: "2021-04-02T20:53:21.341Z",
+            updated_at: "2021-04-02T21:16:36.852Z",
+            bookmarks: [
+              {
+                id: 2,
+                title: "B2",
+                url: "http://fezfzefz.fez",
+                description: null,
+                created_at: "2021-04-02T20:52:15.527Z",
+                updated_at: "2021-04-02T21:15:35.603Z",
+              },
+            ],
+            children: [],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: "C",
+    parent: null,
+    created_at: "2021-04-02T20:53:03.600Z",
+    updated_at: "2021-04-02T21:16:31.834Z",
+    bookmarks: [
+      {
+        id: 2,
+        title: "B2",
+        url: "http://fezfzefz.fez",
+        description: null,
+        created_at: "2021-04-02T20:52:15.527Z",
+        updated_at: "2021-04-02T21:15:35.603Z",
+      },
+    ],
+    children: [],
+  },
+];

--- a/test/strapi/data.test.js
+++ b/test/strapi/data.test.js
@@ -191,25 +191,30 @@ export const classicalFoldersExpectedResult = [
     type: "directory",
     title: "A",
     childrens: [
-      { id: 1, itle: "B1", url: "http://dzad.fr" },
+      { id: 1, title: "B1", url: "http://dzad.fr", type: "bookmark" },
       {
         id: 2,
         type: "directory",
         title: "B",
         childrens: [
-          { id: 2, itle: "B2", url: "http://fezfzefz.fez" },
-          { id: 3, itle: "B3", url: "http://dadazdaf.fre" },
+          { id: 2, title: "B2", url: "http://fezfzefz.fez", type: "bookmark" },
+          { id: 3, title: "B3", url: "http://dadazdaf.fre", type: "bookmark" },
           {
             id: 4,
             type: "directory",
             title: "D",
-            childrens: [{ id: 2, itle: "B2", url: "http://fezfzefz.fez" }],
+            childrens: [{ id: 2, title: "B2", url: "http://fezfzefz.fez", type: "bookmark" }],
           },
         ],
       },
     ],
   },
-  { id: 3, type: "directory", title: "C", childrens: [{ id: 2, itle: "B2", url: "http://fezfzefz.fez" }] },
+  {
+    id: 3,
+    type: "directory",
+    title: "C",
+    childrens: [{ id: 2, title: "B2", url: "http://fezfzefz.fez", type: "bookmark" }],
+  },
 ];
 
 export const strapiConfig = { strapiUrl: "http://mock.test/", strapiJwt: "jwtMock" };

--- a/test/strapi/provider.test.js
+++ b/test/strapi/provider.test.js
@@ -2,17 +2,18 @@ import StrapiHttpClient from "../../src/js/strapi/api";
 import { loadBookmarksTree } from "../../src/js/strapi/provider";
 import { assert } from "chai";
 import sinon from "sinon";
-import { classicalTags, classicalTagsExpectedResult, strapiConfig } from "./data.test";
+import { classicalFoldersExpectedResult, classicalFolders, strapiConfig } from "./data.test";
 
 describe("strapi/provider", () => {
   describe("#loadBookmarksTree()", () => {
     before(() => {
-      sinon.stub(StrapiHttpClient.prototype, "getTags").returns(classicalTags);
+      sinon.stub(StrapiHttpClient.prototype, "getFoldersTree").returns(classicalFolders);
     });
 
     it("should loadBookmarksTree without error", async () => {
       const bookmarks = await loadBookmarksTree(strapiConfig);
-      assert.deepEqual(bookmarks, classicalTagsExpectedResult);
+      // console.log(JSON.stringify(bookmarks));
+      assert.deepEqual(bookmarks, classicalFoldersExpectedResult);
     });
   });
 });


### PR DESCRIPTION
Changing provider and tests for folders tree

![image](https://user-images.githubusercontent.com/2108171/113673817-b97c9d80-96b9-11eb-9924-95ad40c2cf48.png)

BREAKING CHANGE: Before, we scrapped tag categories for folders; and now we moved to the new model
'folders'

fix #39